### PR TITLE
Move to Gradle dependencies

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -41,7 +41,7 @@
       <string name="banid">ca-app-pub-8440343014846849/3119840614</string>
       <string name="intid">ca-app-pub-8440343014846849/4596573817</string>
     </config-file-->
-    <dependency id="cordova-google-play-services" />
+    <framework src="com.google.android.gms:play-services:+" />
 
     <source-file src="src/android/AdMobAds.java" target-dir="src/com/appfeel/cordova/admob" />
     <source-file src="src/android/AdMobAdsAdListener.java" target-dir="src/com/appfeel/cordova/admob" />


### PR DESCRIPTION
I propose that you move to Gradle based dependency rather than a dependent plugin. When you link in the other plugin it may cause multiple dexing issues with other plugins.