### PR TITLE
fix with cordova v9

### DIFF
--- a/scripts/100-prepare-admob-angular.js
+++ b/scripts/100-prepare-admob-angular.js
@@ -4,7 +4,7 @@ var fs = require('fs'),
     path = require('path');
 
 module.exports = function (context) {
-    var deferred = new context.requireCordovaModule('q').defer(),
+    var deferred = new require('q').defer(),
         src = path.resolve(context.opts.plugin.dir, 'www'),
         www = path.resolve(context.opts.projectRoot, 'www'),
         lib = path.resolve(context.opts.projectRoot, 'www', 'lib'),
@@ -58,7 +58,7 @@ function showErrorNotice(context, err) {
 }
 
 function ensureExists(context, path, mask) {
-    var deferred = new context.requireCordovaModule('q').defer();
+    var deferred = new require('q').defer();
     if (typeof mask == 'function') { // allow the `mask` parameter to be optional
         cb = mask;
         mask = 0777;


### PR DESCRIPTION
> CordovaError: Using "requireCordovaModule" to load non-cordova module "q" is not supported. Instead, add this module to your dependencies and use regular "require" to load it.